### PR TITLE
Fix 'no cond clause evaluated to a truthy value' in 'Packet.encode_fields/1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,53 @@
 # Changelog
 
+## v0.11.2
+
+- Fix `no cond clause evaluated to a truthy value` in `Fluxter.Packet.encode_value/1`
+
+## v0.11.1
+
+- Make lib releasable on private hex.
+
+### Before fork:
+
 ## v0.10.0
 
-  * Dropped support for Elixir versions older than 1.5.
+- Dropped support for Elixir versions older than 1.5.
 
 ## v0.9.1
 
-  * Fixed the order when building prefix.
+- Fixed the order when building prefix.
 
 ## v0.9.0
 
-  * Fixed prefix building when start options provided.
-  * Dropped support for Elixir v1.2.
+- Fixed prefix building when start options provided.
+- Dropped support for Elixir v1.2.
 
 ## v0.8.1
 
-  * Fixed port command for OTP versions that support ancillary data sending.
+- Fixed port command for OTP versions that support ancillary data sending.
 
 ## v0.8.0
 
-  * Added support for module, function, arguments tuple in `measure/4`.
+- Added support for module, function, arguments tuple in `measure/4`.
 
 ## v0.7.1
 
-  * Fixed Elixir v1.6 warnings.
+- Fixed Elixir v1.6 warnings.
 
 ## v0.7.0
 
-  * Added the `c:Fluxter.start_link/1` callback to support runtime configuration.
+- Added the `c:Fluxter.start_link/1` callback to support runtime configuration.
 
-__Deprecations:__
+**Deprecations:**
 
-  * Passing child specification options to `child_spec/1` is deprecated.
+- Passing child specification options to `child_spec/1` is deprecated.
 
 ## v0.6.1
 
-  * Fixed a bug in the `c:Fluxter.child_spec/1` callback.
+- Fixed a bug in the `c:Fluxter.child_spec/1` callback.
 
 ## v0.6.0
 
-  * Added the `c:Fluxter.child_spec/1` callback.
-  * Started flushing counters synchronously when calling `Fluxter.flush_counter/1`.
+- Added the `c:Fluxter.child_spec/1` callback.
+- Started flushing counters synchronously when calling `Fluxter.flush_counter/1`.

--- a/lib/fluxter/packet.ex
+++ b/lib/fluxter/packet.ex
@@ -64,6 +64,9 @@ defmodule Fluxter.Packet do
 
       is_binary(val) ->
         [?\", escape(val, '"'), ?\"]
+
+      true ->
+        inspect(val)
     end
   end
 


### PR DESCRIPTION
Should fix these errors: https://appsignal.com/relay-1/sites/5ed530475ac13f0c0576f9c3/exceptions/incidents/234/samples/5ed530475ac13f0c0576f9c3-66925959725901527716861425602